### PR TITLE
index: fix the "quickly install" link

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -32,13 +32,15 @@ Quay is a container image registry that enables you to build, organize, distribu
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
               <h2>Run Project Quay in a Container</h2>
               <p>
-                Want to get started quickly and easily? Just <a href="https://docs.projectquay.io/latest/getting_started/administrators.html#running-in-a-docker-container">run Project Quay in a container</a> by itself.
+                Want to get started quickly and easily? Just <a href="https://docs.projectquay.io/latest/getting_started/administrators.html#running-in-a-docker-container">
+                run Project Quay in a container</a> by itself.
               </p>
             </div>
                     <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
               <h2>Run Project Quay on Kubernetes</h2>
               <p>
-                Use the <%= link_to "Quay Setup Operator", "https://github.com/redhat-cop/quay-operator" %> to <a href="https://docs.projectquay.io/latest/getting_started/running-on-openshift.html">quickly install Project Quay on OpenShift or Kubernetes.
+                Use the <%= link_to "Quay Setup Operator", "https://github.com/redhat-cop/quay-operator" %> to
+                <a href="https://docs.projectquay.io/latest/getting_started/running-on-openshift.html">quickly install Project Quay on OpenShift or Kubernetes</a>.
               </p>
             </div>
           </div>

--- a/source/layouts/_navbar.erb
+++ b/source/layouts/_navbar.erb
@@ -16,14 +16,11 @@
             <a href="/#contribute">CONTRIBUTE</a>
           </li>
           <li>
-            <a href="https://commons.openshift.org/">COMMUNITY</a>
-          </li>
-          <li>
             <a href="https://docs.projectquay.io/latest/welcome/index.html">DOCUMENTATION</a>
           </li>
           <li>
             <!-- Place this tag where you want the button to render. -->
-            <a aria-label="Star openshift/origin on GitHub" data-count-aria-label="# stargazers on GitHub" data-count-api="/repos/openshift/origin#stargazers_count" data-count-href="/openshift/origin/stargazers" data-style="mega" data-icon="octicon-star" href="https://github.com/openshift/origin" class="github-button">Star</a>
+            <a aria-label="Star Project Quay on GitHub" data-count-aria-label="# stargazers on GitHub" data-count-api="/repos/quay/quay#stargazers_count" data-count-href="/quay/quay/stargazers" data-style="mega" data-icon="octicon-star" href="https://github.com/quay/quay" class="github-button">Star</a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
* Adds the missing `</a>` tag; closes #51
* Removes the "Community" link and adjusts the GitHub Star link in the
  navbar

Signed-off-by: Jiri Fiala <jfiala@redhat.com>