### PR TITLE
add link to announcement blog

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -107,6 +107,10 @@ Quay is a container image registry that enables you to build, organize, distribu
                   Check the <a href="https://github.com/quay/quay/blob/master/README.md" target="_blank">README file</a> for more
                   information on the latest release of Project Quay.
                 </p>
+                <p>
+                  Read  <a href="https://www.redhat.com/en/blog/red-hat-introduces-open-source-project-quay-container-registry" target="_blank">the announcement post</a> for more
+                  information on the open sourcing of Project Quay.
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
https://www.redhat.com/en/blog/red-hat-introduces-open-source-project-quay-container-registry